### PR TITLE
changing logic at the suggestion of Keiji Suzuki to address an issue…

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseCreateDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseCreateDAO.java
@@ -189,8 +189,8 @@ public class SolrBrowseCreateDAO implements BrowseCreateDAO,
 
                                     // is there any valid (with appropriate
                                     // confidence) authority key?
-                                    if ((ignoreAuthority && !bi.isAuthorityIndex())
-                                            || (values[x].authority != null && values[x].confidence >= minConfidence))
+                                    if (!ignoreAuthority && !bi.isAuthorityIndex()
+                                            && values[x].authority != null && values[x].confidence >= minConfidence)
                                     {
                                         distFAuths.add(values[x].authority);
                                         distValuesForAC.add(values[x].value);


### PR DESCRIPTION
Without this suggested logic change, authority keys still show in browse headings. Code is tested and in production.
